### PR TITLE
Update libraries

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
   <package id="NUnit.Runners" version="2.6.2" />
-  <package id="RabbitMQ.Client" version="3.0.2" targetFramework="net45" />
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.3.2" targetFramework="net40" />
 </packages>

--- a/sample.console.client/sample.console.client.csproj
+++ b/sample.console.client/sample.console.client.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/AmqpClientProperties.cs
+++ b/src/AmqpClientProperties.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -7,9 +6,9 @@ namespace rabbitmq.log4net.gelf.appender
 {
     public class AmqpClientProperties
     {
-        public static IDictionary WithFacility(IKnowAboutConfiguredFacility facilityInformation)
+        public static IDictionary<string,object> WithFacility(IKnowAboutConfiguredFacility facilityInformation)
         {
-            var properties = new Dictionary<string, string>();
+            var properties = new Dictionary<string, object>();
             var executingAssemblyName = Assembly.GetExecutingAssembly().GetName();
             properties.Add(Properties.Product, executingAssemblyName.Name);
             properties.Add(Properties.Version, executingAssemblyName.Version.ToString());

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.0.2" targetFramework="net40" />
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
+  <package id="RabbitMQ.Client" version="3.3.2" targetFramework="net40" />
 </packages>

--- a/src/rabbitmq.log4net.gelf.appender.csproj
+++ b/src/rabbitmq.log4net.gelf.appender.csproj
@@ -34,17 +34,15 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.0.2.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RabbitMQ.Client.3.0.2\lib\net30\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client">
+      <HintPath>..\packages\RabbitMQ.Client.3.3.2\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/TestingRabbitListener.cs
+++ b/tests/TestingRabbitListener.cs
@@ -34,7 +34,7 @@ namespace tests
             var consumerQueue = model.QueueDeclare(queueName, false, true, true, null);
             model.QueueBind(consumerQueue, exchangeName, "#");
 
-            var consumer = new EventingBasicConsumer();
+            var consumer = new EventingBasicConsumer(model);
             consumer.Received += (o, e) =>
                                      {
                                          var data = Encoding.ASCII.GetString(e.Body);

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -35,14 +35,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.0\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL" />
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="RabbitMQ.Client">
-      <HintPath>..\packages\RabbitMQ.Client.3.0.2\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\packages\RabbitMQ.Client.3.3.2\lib\net30\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Log4net
Json.Net
RabbitMq

Not compatible with last versions of Log4net and RabbitMQ, please use
0.2.0 if you want to use older version