### PR TITLE
Exposes more rabbit mq settings to the appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sample config
   </configSections>
   
   <log4net>
-    <appender name="rabbitmq.gelf.appender" type="rabbitmq.log4net.gelf.appender.GelfRabbitMqAdapter, rabbitmq.log4net.gelf.appender">
+    <appender name="rabbitmq.gelf.appender" type="rabbitmq.log4net.gelf.appender.GelfRabbitMqAppender, rabbitmq.log4net.gelf.appender">
       <HostName value="localhost" />
       <VirtualHost value="/" />
       <Port value="5672" />

--- a/src/GelfRabbitMqAppender.cs
+++ b/src/GelfRabbitMqAppender.cs
@@ -15,6 +15,7 @@ namespace rabbitmq.log4net.gelf.appender
         public string Password { get; set; }
         public string Facility { get; set; }
         public bool Durable { get; set; }
+        public string ExchangeType { get; set; }
 
         protected readonly GelfAdapter gelfAdapter;
         private IConnection connection;
@@ -37,6 +38,7 @@ namespace rabbitmq.log4net.gelf.appender
             Exchange = "log4net.gelf.appender";
             Username = "guest";
             Password = "guest";
+            ExchangeType = "topic";
         }
 
         public override void ActivateOptions()
@@ -63,7 +65,7 @@ namespace rabbitmq.log4net.gelf.appender
             connection = CreateConnectionFactory().CreateConnection();
             connection.ConnectionShutdown += ConnectionShutdown;
             model = connection.CreateModel();
-            model.ExchangeDeclare(Exchange, ExchangeType.Topic, Durable);
+            model.ExchangeDeclare(Exchange, ExchangeType, Durable);
         }
 
         private void ConnectionShutdown(IConnection shutingDownConnection, ShutdownEventArgs reason)
@@ -105,7 +107,7 @@ namespace rabbitmq.log4net.gelf.appender
         protected override void Append(LoggingEvent loggingEvent)
         {
             EnsureConnectionIsOpen();
-            model.ExchangeDeclare(Exchange, ExchangeType.Topic, Durable);
+            model.ExchangeDeclare(Exchange, ExchangeType, Durable);
             var messageBody = gelfAdapter.Adapt(loggingEvent).AsJson();
             model.BasicPublish(Exchange, "log4net.gelf.appender", true, null, messageBody.AsByteArray());
         }

--- a/src/GelfRabbitMqAppender.cs
+++ b/src/GelfRabbitMqAppender.cs
@@ -16,6 +16,7 @@ namespace rabbitmq.log4net.gelf.appender
         public string Facility { get; set; }
         public bool Durable { get; set; }
         public string ExchangeType { get; set; }
+        public string RoutingKey { get; set; }
 
         protected readonly GelfAdapter gelfAdapter;
         private IConnection connection;
@@ -39,6 +40,7 @@ namespace rabbitmq.log4net.gelf.appender
             Username = "guest";
             Password = "guest";
             ExchangeType = "topic";
+            RoutingKey = "log4net.gelf.appender";
         }
 
         public override void ActivateOptions()
@@ -109,7 +111,7 @@ namespace rabbitmq.log4net.gelf.appender
             EnsureConnectionIsOpen();
             model.ExchangeDeclare(Exchange, ExchangeType, Durable);
             var messageBody = gelfAdapter.Adapt(loggingEvent).AsJson();
-            model.BasicPublish(Exchange, "log4net.gelf.appender", true, null, messageBody.AsByteArray());
+            model.BasicPublish(Exchange, RoutingKey, true, null, messageBody.AsByteArray());
         }
 
         protected override void OnClose()


### PR DESCRIPTION
There are three changes is this MR
* Quick fix to the ReadMe that I mentioned in Issue #12 
* Exposes the ExchangeType for applications posting logs to an exchange rather than the queue itself.
* Exposes the RoutingKey. The hard coded routing key was erroring out when using exchanges.

All of these changes have been tested in the sample app. I also set the defaults to the previous hardcoded values so this shouldn't break any existing applications using this handler.